### PR TITLE
Use ObjectManager for Instance Creation

### DIFF
--- a/Classes/Domain/Repository/BlockRepository.php
+++ b/Classes/Domain/Repository/BlockRepository.php
@@ -106,7 +106,7 @@ class BlockRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
     {
         static $tableName = null;
         if ($tableName === null) {
-            $tableName = GeneralUtility::makeInstance(
+            $tableName = $this->objectManager->get(
                 \TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapper::class
             )->convertClassNameToTableName(
                 \TYPO3\CMS\Core\Utility\ClassNamingUtility::translateRepositoryNameToModelName(get_class($this))


### PR DESCRIPTION
Use `$this->objectManager->get(` instead of `GeneralUtility::makeInstance(` to create an Instance of DataMapper. Otherwise not all dependencies are initialised. The usage of `GeneralUtility::makeInstance(` will lead to the following Exception if the module is called in Backend:
`Call to a member function buildDataMap() on null`